### PR TITLE
reset big chat state if secondary panel tab clicked

### DIFF
--- a/src/data/elements.js
+++ b/src/data/elements.js
@@ -13,6 +13,12 @@ const Elements = {
     selector: `[class^="home_home"]`,
     class: "home_home__pUFCA",
   },
+  secondaryPanel: {
+    tab: {
+      class: "secondary-panel_tab__PxWtZ",
+      selector: `[class*="secondary-panel_tab__"]`,
+    },
+  },
   header: {
     selector: `[class*="top-bar_top-bar__"]`,
     class: "top-bar_top-bar___Z0QX",

--- a/src/modules/events.js
+++ b/src/modules/events.js
@@ -132,6 +132,22 @@ export const leftClick = (event) => {
       break;
   }
 
+  function checkSecondaryPanelTabClicked() {
+    const clicked = hasClass(
+      event.target.parentElement?.parentElement,
+      ELEMENTS.secondaryPanel.tab.class
+    );
+
+    if (clicked) {
+      const returnToBigChat =
+        config.get("enableBigChat") && config.get("bigChatState");
+
+      setTimeout(() => toggleBigChat(returnToBigChat, true), 0);
+      return true;
+    }
+    return false;
+  }
+
   function checkAvatarClicked() {
     const clicked = hasClass(
       event.target.parentElement,
@@ -161,6 +177,7 @@ export const leftClick = (event) => {
   function checkForTarget() {
     if (checkChattersClicked()) return;
     if (checkAvatarClicked()) return;
+    if (checkSecondaryPanelTabClicked()) return;
   }
 
   function isMenuItem() {

--- a/src/modules/functions.js
+++ b/src/modules/functions.js
@@ -687,7 +687,7 @@ export const startMaejokTools = async () => {
   }
 
   if (cfg.persistBigChat && !isPopoutChat) {
-    toggleBigChat(cfg.bigChatState, cfg.bigChatState);
+    toggleBigChat(cfg.bigChatState, true);
   }
 
   if (!isPopoutChat) {


### PR DESCRIPTION
Corrects an issue possibly caused by a re-render on secondary panel tab (missions, log, poll) clicks.

Added a click event check.  Restores `bigChatState=true` if needed. 

Messy, but works for now 