### PR TITLE
Fix plugin load

### DIFF
--- a/src/modules/functions.js
+++ b/src/modules/functions.js
@@ -332,12 +332,16 @@ export const getSender = function (messageElement, messageType) {
 
 
 export const getUserData = async (userId) => {
-  const data = await fetchFromFishtank(
-    "get",
-    `https://www.fishtank.live/api/user/get?uid=${userId}`
-  );
+  try {
+    const data = await fetchFromFishtank(
+      "get",
+      `https://www.fishtank.live/api/user/get?uid=${userId}`
+    );
+  } catch (error) {
+    return false;
+  }
 
-  return data || false;
+  return data;
 };
 
 export const findUserByName = (displayName) => {


### PR DESCRIPTION
### Description
Heard from some people that the plugin wasn't loading at all for them.  After clearing my cache I was able to reproduce.

<img width="1157" alt="image" src="https://github.com/maejok-xx/maejok-tools/assets/159047967/c212926f-1bdf-4460-a673-ea73f37cb817">

Looks like the api changed and this 404 for some reason throws an error that was not caught.  I'm a little confused because the callsite for the function I'm changing is already wrapped in a try catch.  I think it may have more to do with clearInterval than moving the exception handling closer to the api call, but idk it's late and I'm tired and this allows the plugin to load lol.

I'll work tomorrow on trying to actually fix this some more because I'm sure there are a few things that are broken with removal of that endpoint, like muting, and other profile stuff.