### PR TITLE
Select bigscreen styles based on live status

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -11,6 +11,7 @@ import {
   toggleScanLines,
   getReactProps,
   getUserData,
+  getShowLiveStatus,
 } from "./modules/functions";
 import { checkForUpdate } from "./modules/updater";
 import "./styles/styles.scss";
@@ -42,8 +43,9 @@ import "./styles/styles.scss";
     livestreams,
     directorMode,
     isShowLive = null;
-  let hasFetchedUserData = false;
-  let isPopoutChat = false;
+  let hasFetchedUserData,
+    hasFetchedShowLiveStatus,
+    isPopoutChat = false;
 
   if (config.get("hideGlobalMissions")) {
     observers.body.start();
@@ -64,7 +66,14 @@ import "./styles/styles.scss";
       isLoaded =
         (directorMode !== null && chat !== null && livestreams !== null) ||
         (directorMode === null && chat !== null);
-      isShowLive = directorMode !== null;
+
+      const liveStatusFetched =
+        state.get("isShowLive") || hasFetchedShowLiveStatus;
+      if (!liveStatusFetched) {
+        hasFetchedShowLiveStatus = true;
+        isShowLive = getShowLiveStatus();
+        state.set("isShowLive", isShowLive);
+      }
     }
 
     if (chat && !updateChecked) {

--- a/src/modules/constants.js
+++ b/src/modules/constants.js
@@ -146,7 +146,7 @@ export const SCREEN_TAKEOVERS_STYLES = `
 }
 `;
 
-export const BIG_SCREEN_STYLES = `
+export const BIG_SCREEN_STYLES_ONLINE = `
 .home_home__pUFCA .home_center__6GW_l {
   grid-column: 1/4;
   grid-row: 1/6;
@@ -199,6 +199,24 @@ export const BIG_SCREEN_STYLES = `
   img {
     display: none;
   }
+}
+`;
+
+export const BIG_SCREEN_STYLES_OFFLINE = `
+.home_home__pUFCA .home_right__j_b3u {
+  grid-column: 1/4;
+  grid-row: 1/6;
+}
+
+.top-bar_top-bar___Z0QX,
+.secondary-panel_secondary-panel__vUc65,
+.experience-bar_experience-bar__nVDge,
+.announcement_announcement__Sow3P,
+.home_left__UiQ0z,
+.home_center-bottom__zlpWm,
+.home_center__6GW_l,
+.tts-history_tts-history__8_9eB  {
+  display: none !important;
 }
 `;
 
@@ -278,7 +296,7 @@ export const ROOMS = {
     name: "Master Bathroom",
     switchTo: () => {},
   },
-  "confessional": {
+  confessional: {
     id: "confessional",
     name: "Confessional",
     switchTo: () => {},
@@ -400,10 +418,10 @@ export const DEFAULT_KEYBINDS = {
     shiftKey: false,
     code: "F4",
   },
-  "confessional": {
+  confessional: {
     ctrlKey: false,
     altKey: false,
     shiftKey: false,
     code: "F6",
-  }
+  },
 };

--- a/src/modules/functions.js
+++ b/src/modules/functions.js
@@ -5,7 +5,8 @@ import {
   SOUNDS,
   DARK_MODE_STYLES,
   SCREEN_TAKEOVERS_STYLES,
-  BIG_SCREEN_STYLES,
+  BIG_SCREEN_STYLES_ONLINE,
+  BIG_SCREEN_STYLES_OFFLINE,
   DEFAULT_KEYBINDS,
   REPO_URL_ROOT,
 } from "./constants";
@@ -152,6 +153,20 @@ export const toggleScanLines = (toggle) => {
   body.classList.toggle("maejok-hide-scan_lines", toggle);
 };
 
+export const getShowLiveStatus = () => {
+  const status = localStorage.getItem("live-streams-status");
+  let online = false;
+
+  if (status) {
+    const value = JSON.parse(status).value;
+    online = Object.values(value).some(function (s) {
+      return s === "online";
+    });
+  }
+
+  return online;
+};
+
 export const toggleBigScreen = (mode = null, muted = false) => {
   if (config.get("enableBigScreen")) {
     if (!muted) {
@@ -170,9 +185,13 @@ export const toggleBigScreen = (mode = null, muted = false) => {
 
   state.set("bigScreenState", mode);
 
+  const big_screen_styles = state.get("isShowLive")
+    ? BIG_SCREEN_STYLES_ONLINE
+    : BIG_SCREEN_STYLES_OFFLINE;
+
   if (mode) {
     const style = document.createElement("style");
-    style.textContent = BIG_SCREEN_STYLES;
+    style.textContent = big_screen_styles;
     style.setAttribute("id", "maejok-bigscreen");
     document.head.appendChild(style);
   } else {

--- a/src/modules/state.js
+++ b/src/modules/state.js
@@ -23,6 +23,7 @@ const State = () => {
     updateShown: false,
     audioElement: false,
     pendingKeybind: null,
+    isShowLive: false,
   };
 
   const get = (key) => {


### PR DESCRIPTION
### Description
closes https://github.com/maejok-xx/maejok-tools/issues/57

When the streams are not live based on response from https://api.fishtank.live/v1/live-streams, apply different styles for bigscreen mode.

### Open questions
Was debating the offline mode having a small left panel with the missions and inventory on the left or just having it all be chat

Also, should there be an 'X' to close - toggling the shortcut works, but maybe it'd be convenient to have that as well.

### Screenshots

<img width="1502" alt="image" src="https://github.com/maejok-xx/maejok-tools/assets/159047967/50e2956f-e883-4086-9fe4-a9f58de70a0d">
