### PR TITLE
Override chat padding when avatars hidden

### DIFF
--- a/src/modules/settings.js
+++ b/src/modules/settings.js
@@ -134,6 +134,13 @@ export const applySettingsToChat = () => {
 
   state.set("contextUser", null);
 
+  const chatContainer = document.getElementById("chat-messages");
+  if (config.get("hideAvatars")) {
+    chatContainer.style.padding = "0px";
+  } else {
+    chatContainer.style.padding = "8px";
+  }
+
   toggleDenseChat();
 };
 

--- a/src/styles/components/_overrides.scss
+++ b/src/styles/components/_overrides.scss
@@ -1,8 +1,3 @@
-.chat_chat__2rdNg .chat_messages__2IBEJ {
-  padding: 0;
-  border: 0;
-}
-
 button.top-bar_clan-invite__Gv9N_ {
   right: -75% !important;
 }


### PR DESCRIPTION
### Description
closes https://github.com/maejok-xx/maejok-tools/issues/67

I'm guessing the padding override was intentional - seems to have been there since the plugin was created.  It looks fine when avatars and other message elements are hidden, but does look a bit weird with default chat - the level numbers and avatar clash with the chat border.

This removes the override as a default, but removes the padding when avatars are hidden.

### Before
<img width="387" alt="image" src="https://github.com/user-attachments/assets/4084ebb6-ab77-4999-bf18-8aba5c601054">

### After
- default

<img width="357" alt="image" src="https://github.com/user-attachments/assets/0b65fbc6-c74b-4634-acc0-9dc336476c38">


- avatars hidden
<img width="360" alt="image" src="https://github.com/user-attachments/assets/74611d24-0d8e-47c2-a92b-c0dcf268db29">
