### PR TITLE
Add video control hide shortcut

### DIFF
--- a/src/classes/Modal.js
+++ b/src/classes/Modal.js
@@ -2,6 +2,7 @@ import state from "../modules/state";
 import * as events from "../modules/events";
 import * as functions from "../modules/functions";
 import ELEMENTS from "../data/elements";
+import { CLOSE_SVG } from "../modules/constants";
 
 export default class Modal {
   constructor(title, body) {
@@ -53,8 +54,9 @@ export default class Modal {
     closeButton.classList.add(...ELEMENTS.modal.close.button.classes);
     closeButton.addEventListener("click", () => events.clickCloseModal(this));
 
-    const closeButtonIcon = document.createElement("img");
-    closeButtonIcon.setAttribute(...ELEMENTS.modal.close.button.image.attr);
+    const closeButtonIcon = document.createElement("div");
+    closeButtonIcon.classList.add(ELEMENTS.modal.close.icon.class);
+    closeButtonIcon.innerHTML = CLOSE_SVG;
 
     this.body = document.createElement("div");
     this.body.classList.add(ELEMENTS.modal.body.class);

--- a/src/data/elements.js
+++ b/src/data/elements.js
@@ -20,6 +20,10 @@ const Elements = {
       selector: `[class*="live-streams_live-streams-grid__"]`,
       class: "live-streams_live-streams-grid__Tp4ah",
     },
+    controls: {
+      selector: `[class^="livepeer-video-player_controls"]`,
+      class: "livepeer-video-player_controls__y36El",
+    },
   },
   secondaryPanel: {
     tab: {
@@ -358,13 +362,10 @@ const Elements = {
       button: {
         selector: `[class^="close-button"]`,
         classes: ["close-button_close-button__BKUKA", "close-button_sm__n0dZT"],
-        image: {
-          attr: [
-            `src`,
-            // UPDATE TO GITHUB
-            `https://cdn.fishtank.live/images/slices/close.png`,
-          ],
-        },
+      },
+      icon: {
+        selector: `[class^="icon_icon]`,
+        class: "icon_icon__bDzMA",
       },
     },
     title: {

--- a/src/modules/config.js
+++ b/src/modules/config.js
@@ -11,6 +11,7 @@ const Config = () => {
     enableBigScreen: true,
     persistBigScreen: false,
     bigScreenState: false,
+    controlOverlayState: false,
     disableSoundEffects: false,
     hideGlobalMissions: false,
     hideScreenTakeovers: false,

--- a/src/modules/config.js
+++ b/src/modules/config.js
@@ -11,6 +11,7 @@ const Config = () => {
     enableBigScreen: true,
     persistBigScreen: false,
     bigScreenState: false,
+    enableControlOverlay: false,
     controlOverlayState: false,
     disableSoundEffects: false,
     hideGlobalMissions: false,
@@ -167,6 +168,19 @@ const Config = () => {
               help: {
                 label: "?",
                 text: `<p>Enabling this option will restore the last <strong>Big Screen Mode</strong> state upon refreshing the site.</p>`,
+              },
+            },
+            // enableVideoControls
+            {
+              name: "enableControlOverlay",
+              label: "Enable Video Control Overlay",
+              type: "toggle",
+              value: cfg.enableControlOverlay,
+              group: "site-options",
+              help: {
+                label: "?",
+                text: `<p>Enabling this option creates a keyboard shortcut to toggle <strong>the video controls overlay</strong> which will show or hide the overlay.</p>
+                <p>Keyboard Shortcut: <strong>CTRL+SHIFT+H</strong></p>`,
               },
             },
             // enableDimMode

--- a/src/modules/config.js
+++ b/src/modules/config.js
@@ -173,7 +173,7 @@ const Config = () => {
             // enableVideoControls
             {
               name: "enableControlOverlay",
-              label: "Enable Video Control Overlay",
+              label: "Enable Video Control Overlay Shortcut",
               type: "toggle",
               value: cfg.enableControlOverlay,
               group: "site-options",

--- a/src/modules/constants.js
+++ b/src/modules/constants.js
@@ -425,3 +425,5 @@ export const DEFAULT_KEYBINDS = {
     code: "F6",
   },
 };
+
+export const CLOSE_SVG = `<svg fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="32" height="32"><path d="M5 3H3v18h18V3H5zm14 2v14H5V5h14zm-8 4H9V7H7v2h2v2h2v2H9v2H7v2h2v-2h2v-2h2v2h2v2h2v-2h-2v-2h-2v-2h2V9h2V7h-2v2h-2v2h-2V9z" fill="currentColor"></path></svg>`;

--- a/src/modules/events.js
+++ b/src/modules/events.js
@@ -14,6 +14,7 @@ import {
   existsInUserList,
   modifyUserList,
   toggleBigScreen,
+  toggleControlOverlay,
   playSound,
   setChatInputValue,
   toggleItemInList,
@@ -138,17 +139,31 @@ export const leftClick = (event) => {
 
   function checkClickedItem() {
     const targets = {
-      [ELEMENTS.chat.message.sender.class]: { target: target, item:  "chatUsername" },
-      [ELEMENTS.chat.message.avatar.class]: { target: target.parentElement, item: "chatAvatar" },
-      [ELEMENTS.chat.header.presence.wrapper.class]: { target: target.parentElement, item: "recentChatters" },
-      [ELEMENTS.chat.header.presence.class]: { target: target.parentElement, item: "recentChatters" },
-      [ELEMENTS.secondaryPanel.tab.class]: {target: target.parentElement?.parentElement, item: "bigScreen" },
-
+      [ELEMENTS.chat.message.sender.class]: {
+        target: target,
+        item: "chatUsername",
+      },
+      [ELEMENTS.chat.message.avatar.class]: {
+        target: target.parentElement,
+        item: "chatAvatar",
+      },
+      [ELEMENTS.chat.header.presence.wrapper.class]: {
+        target: target.parentElement,
+        item: "recentChatters",
+      },
+      [ELEMENTS.chat.header.presence.class]: {
+        target: target.parentElement,
+        item: "recentChatters",
+      },
+      [ELEMENTS.secondaryPanel.tab.class]: {
+        target: target.parentElement?.parentElement,
+        item: "bigScreen",
+      },
     };
 
     let foundTarget;
     for (const [targetClass, value] of Object.entries(targets)) {
-      let currentTarget = value.target
+      let currentTarget = value.target;
 
       if (currentTarget.classList.contains(targetClass)) {
         foundTarget = value.item;
@@ -199,10 +214,13 @@ export const keyPress = (event) => {
     return;
   }
 
+  console.log(event.code);
+
   const keys = {
     backtick: "Backquote",
     space: "Space",
     escape: "Escape",
+    h: "KeyH",
   };
 
   if (
@@ -210,6 +228,11 @@ export const keyPress = (event) => {
     (event.ctrlKey && event.shiftKey && event.code === keys.space)
   ) {
     toggleBigScreen();
+    return;
+  }
+
+  if (event.ctrlKey && event.shiftKey && event.code === keys.h) {
+    toggleControlOverlay();
     return;
   }
 
@@ -386,7 +409,7 @@ export const clickTabButton = (tab, element) => {
   const wrapper = element.parentElement;
 
   for (const child of wrapper.children) {
-    child.classList.remove(activeClass)
+    child.classList.remove(activeClass);
   }
   element.classList.add(activeClass);
 
@@ -500,22 +523,19 @@ export const clickKeybindButton = (button, label, key) => {
   errorText.textContent = "Conflicts with an existing keybind!";
   errorText.style.display = "none";
 
-  const confirmBtn = settings.createButton(
-    "save",
-    function () {
-      playSound("shutter");
-      let bind = state.get("pendingKeybind");
-      if (bind) {
-        let val = {};
-        val[key] = bind;
-        config.set("binds", val);
-        settings.saveSettings();
-        button.textContent = keyEventToString(bind);
-      }
-      state.set("pendingKeybind", null);
-      prompt.destroy();
+  const confirmBtn = settings.createButton("save", function () {
+    playSound("shutter");
+    let bind = state.get("pendingKeybind");
+    if (bind) {
+      let val = {};
+      val[key] = bind;
+      config.set("binds", val);
+      settings.saveSettings();
+      button.textContent = keyEventToString(bind);
     }
-  );
+    state.set("pendingKeybind", null);
+    prompt.destroy();
+  });
 
   const body = document.createElement("div");
   body.classList.add(ELEMENTS.settings.config.help.class);

--- a/src/modules/functions.js
+++ b/src/modules/functions.js
@@ -167,6 +167,21 @@ export const getShowLiveStatus = () => {
   return online;
 };
 
+export const toggleControlOverlay = () => {
+  const videoControls = document.querySelector(
+    ELEMENTS.livestreams.controls.selector
+  );
+
+  const toggle = config.get("controlOverlayState");
+  config.set("controlOverlayState", !toggle);
+
+  if (toggle) {
+    videoControls.style.display = "none";
+  } else {
+    videoControls.style.display = "";
+  }
+};
+
 export const toggleBigScreen = (mode = null, muted = false) => {
   if (config.get("enableBigScreen")) {
     if (!muted) {
@@ -342,13 +357,13 @@ export const getSender = function (messageElement, messageType) {
     ? messageElement
     : messageElement.querySelector(sender.selector);
 
-  const senderText = messageType === "message"
-    ? senderElement.lastChild.textContent
-    : getElementText(senderElement);
+  const senderText =
+    messageType === "message"
+      ? senderElement.lastChild.textContent
+      : getElementText(senderElement);
 
   return senderText;
-}
-
+};
 
 export const getUserData = async (userId) => {
   try {
@@ -1028,7 +1043,7 @@ function toggleLogoHover(toggleState) {
   logo.classList.toggle(logoSelector.hideImg.class, toggleState);
 
   if (toggleState) {
-    const logoHover = document.createElement('img');
+    const logoHover = document.createElement("img");
     logoHover.src = `${REPO_URL_ROOT}/blob/06bddd3e353365fc62df0e1415b4cda3cbf07b14/public/images/logo-full-white-red-eyes.png?raw=true`;
     logoHover.classList.add(...logoSelector.hoverImg.classes);
     logo.insertAdjacentElement("afterend", logoHover);

--- a/src/modules/functions.js
+++ b/src/modules/functions.js
@@ -168,6 +168,9 @@ export const getShowLiveStatus = () => {
 };
 
 export const toggleControlOverlay = () => {
+  if (!config.get("enableControlOverlay")) {
+    return;
+  }
   const videoControls = document.querySelector(
     ELEMENTS.livestreams.controls.selector
   );

--- a/src/styles/components/_settings.scss
+++ b/src/styles/components/_settings.scss
@@ -169,7 +169,7 @@
   text-align: center;
 
   strong {
-    color: $color-black;
+    color: $color-white;
   }
 
   .maejok-modal_roomname,


### PR DESCRIPTION
### Description
Adds setting and shortcut to show or hide the video control overlay when `CTRL+SHIFT+H` shortcut used.

Other minor fixes:
- update modal close button. size of fetched image seems to have changed, and the site was updated to use a different svg anyway.  fix to match site's svg.
- update `<strong>` color to white to avoid dark text on dark background

### Screenshots
#### Video Control Overlay
- bigscreen with overlay
<img width="1493" alt="image" src="https://github.com/user-attachments/assets/9773ba96-866d-4f63-998b-74ca4be9760b">

- bigscreen with overlay hidden
<img width="1504" alt="image" src="https://github.com/user-attachments/assets/a0a90bda-64c0-45a5-bd01-916a6d56e78e">

- setting
<img width="592" alt="image" src="https://github.com/user-attachments/assets/d3645881-80ca-4767-8080-5faaa8e375f8">

- help
<img width="1053" alt="image" src="https://github.com/user-attachments/assets/1c3541f0-68e0-48b6-91ea-c3303e86ab99">

#### Modal Close
- Weird broken modal close button
<img width="696" alt="image" src="https://github.com/user-attachments/assets/8a018c16-31b4-4d64-8cf0-1f8bf1ec950e">

- Updated svg modal close button
<img width="610" alt="image" src="https://github.com/user-attachments/assets/56568eaf-7d12-486f-a68f-3d3890c3bf92">


