### PR TITLE
Fix bigscreen live status check

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -74,7 +74,8 @@ import "./styles/styles.scss";
         state.get("isShowLive") || hasFetchedShowLiveStatus;
       if (!liveStatusFetched) {
         hasFetchedShowLiveStatus = true;
-        isShowLive = getShowLiveStatus();
+        isShowLive = await getShowLiveStatus();
+
         state.set("isShowLive", isShowLive);
       }
     }

--- a/src/modules/events.js
+++ b/src/modules/events.js
@@ -257,8 +257,6 @@ export const keyPress = (event) => {
     return;
   }
 
-  console.log(event.code);
-
   const keys = {
     backtick: "Backquote",
     space: "Space",

--- a/src/modules/functions.js
+++ b/src/modules/functions.js
@@ -154,18 +154,32 @@ export const toggleScanLines = (toggle) => {
   body.classList.toggle("maejok-hide-scan_lines", toggle);
 };
 
-export const getShowLiveStatus = () => {
-  const status = localStorage.getItem("live-streams-status");
+export const getShowLiveStatus = async () => {
+  const livestreams = await fetchLiveStreamStatus();
   let online = false;
 
-  if (status) {
-    const value = JSON.parse(status).value;
-    online = Object.values(value).some(function (s) {
+  if (livestreams) {
+    online = Object.values(livestreams.status).some(function (s) {
       return s === "online";
     });
   }
 
   return online;
+};
+
+const fetchLiveStreamStatus = async () => {
+  const options = {
+    method: "GET",
+  };
+  try {
+    const data = await fetch(
+      `https://api.fishtank.live/v1/live-streams/status`,
+      options
+    );
+    return await data?.json();
+  } catch (error) {
+    return false;
+  }
 };
 
 export const toggleControlOverlay = () => {


### PR DESCRIPTION
### Description
The stream live status check was broken because it was checking the cache for a value that is apparently never actually updated.  This led to the offline styles always being applied, so bigscreen didn't work properly.

So now, it makes an api call to check the stream status when the plugin starts.