### PR TITLE
Add TTS filter warning

### DIFF
--- a/src/modules/config.js
+++ b/src/modules/config.js
@@ -1,4 +1,5 @@
 import state from "./state";
+import { BAD_WORDS } from "./constants";
 import { pluginName } from "./functions";
 import { clickResetKeybindButton } from "./events";
 
@@ -10,6 +11,7 @@ const Config = () => {
 
     enableBigScreen: true,
     enableDragModal: false,
+    enableTTSFilterWarning: false,
     persistBigScreen: false,
     bigScreenState: false,
     enableControlOverlay: false,
@@ -220,6 +222,20 @@ const Config = () => {
               help: {
                 label: "?",
                 text: `<p>Enabling this option will enable dragging of TTS modal to desired location.</p>`,
+              },
+            },
+            // enableTTSFilterWarning
+            {
+              name: "enableTTSFilterWarning",
+              label: "Enable TTS Filter Warning",
+              type: "toggle",
+              value: cfg.enableTTSFilterWarning,
+              group: "site-options",
+              help: {
+                label: "?",
+                text: `<p>Enabling this option will display a warning if your TTS text includes words that will be filtered.
+                <strong><i>This list is dynamic and subject to change on the backend.  It is not exposed on the site, so this list may not catch everything or may otherwise be incorrect.</strong></i></p>
+                <p><strong style="color:white;word-wrap:break-word">Current known filtered words: ${BAD_WORDS.toString()}</strong></p>`,
               },
             },
             // enableEmotesMenu

--- a/src/modules/constants.js
+++ b/src/modules/constants.js
@@ -54,6 +54,28 @@ export const SOUNDS = new Map([
   ["tick-short", "wav"],
 ]);
 
+export const BAD_WORDS = [
+  "nigger",
+  "nigga",
+  "kike",
+  "homo",
+  "tranny",
+  "fag",
+  "slut",
+  "whore",
+  "pedo",
+  "rapist",
+  "paki",
+  "pajeet",
+  "nazi",
+  "hitler",
+  "hooker",
+  "troon",
+  "chink",
+  "negro",
+  "bimbo",
+];
+
 export const DARK_MODE_STYLES = `
 .background_background__fNMDL {
   background: #1c1c1c;

--- a/src/modules/functions.js
+++ b/src/modules/functions.js
@@ -5,6 +5,7 @@ import {
   SOUNDS,
   DARK_MODE_STYLES,
   SCREEN_TAKEOVERS_STYLES,
+  BAD_WORDS,
   BIG_SCREEN_STYLES_ONLINE,
   BIG_SCREEN_STYLES_OFFLINE,
   DEFAULT_KEYBINDS,
@@ -765,6 +766,58 @@ export const muteUser = async (user) => {
 
     i++;
   }, 10);
+};
+
+export const checkTTSFilteredWords = (addedNode) => {
+  if (!config.get("enableTTSFilterWarning")) {
+    return;
+  }
+  const maxAttempts = 5;
+  let retries = 0;
+
+  const checkInputBox = () => {
+    const inputBox = addedNode.querySelector("input");
+
+    if (inputBox) {
+      inputBox.addEventListener("input", function () {
+        const regex = new RegExp(BAD_WORDS.join("|"), "gi");
+        const filterMatches = this.value.match(regex);
+
+        if (filterMatches) {
+          const inputLabel = addedNode.querySelector(
+            ".input_input__Zwrui > span"
+          );
+          const warningContainer = inputLabel.querySelector(
+            ".maejok-tts-warning-text"
+          );
+
+          if (warningContainer) {
+            warningContainer.innerHTML = `Your TTS contains No No words! (${filterMatches.toString()})`;
+            return;
+          }
+
+          inputBox.classList.add("maejok-tts-input-warning-border");
+
+          inputLabel.insertAdjacentHTML(
+            "beforeend",
+            "<div class='maejok-tts-warning-text'>" +
+              `Your TTS contains No No words! (${filterMatches.toString()})` +
+              "</div>"
+          );
+        } else {
+          const input = addedNode.querySelector(".maejok-tts-warning-text");
+          input?.remove();
+          inputBox.classList.remove("maejok-tts-input-warning-border");
+        }
+      });
+    } else if (retries < maxAttempts) {
+      // Use requestAnimationFrame to retry on the next render cycle
+      retries++;
+      requestAnimationFrame(checkInputBox);
+    }
+  };
+
+  requestAnimationFrame(checkInputBox);
 };
 
 export const runUserAgreement = () => {

--- a/src/modules/observers.js
+++ b/src/modules/observers.js
@@ -1,8 +1,13 @@
 import state from "./state";
 import config from "./config";
-import { processChatMessage, getElementText } from "./functions";
+import {
+  processChatMessage,
+  getElementText,
+  checkTTSFilteredWords,
+} from "./functions";
 import ELEMENTS from "../data/elements";
 import { makeDraggable } from "./events";
+import { BAD_WORDS } from "./constants";
 
 const observers = {
   chat: {
@@ -101,6 +106,8 @@ const observers = {
             }
 
             if (addedNode.id === "modal") {
+              checkTTSFilteredWords(addedNode);
+
               const title = getElementText(ELEMENTS.modal.title.text.selector);
 
               const hideMissionsEnabled = config.get("hideGlobalMissions");

--- a/src/modules/settings.js
+++ b/src/modules/settings.js
@@ -50,6 +50,10 @@ export const saveSettings = async () => {
   inputs.forEach((input) => {
     const key = input.id.replace("-hidden", "");
     if (input.type === "checkbox") {
+      if (input.id === "enableTTSFilterWarning" && input.checked) {
+        return createTTSFilterAcknowledgmentModal();
+      }
+
       config.set(key, input.checked ? true : false);
     } else {
       if (key === "updateCheckFrequency") {
@@ -131,6 +135,39 @@ export const saveSettings = async () => {
   }
 
   scrollToBottom();
+};
+
+const createTTSFilterAcknowledgmentModal = () => {
+  const settingsModalButton = document.querySelector(
+    ELEMENTS.modal.close.button.selector
+  );
+  settingsModalButton.click();
+  const data = {
+    title: "TTS Filter Warning Acknowledgement",
+    message: `Confirm to acknowledge that this feature relies on a hardcoded list
+      that may not accurately reflect what is and isn't filtered on the site.`,
+    confirm: () => acknowledgeModal(true),
+    close: () => acknowledgeModal(false),
+  };
+
+  const customConfirmEvent = new CustomEvent("modalopenconfirm", {
+    detail: {
+      data: JSON.stringify(data),
+      onConfirm: data.confirm,
+      onClose: data.close,
+    },
+  });
+
+  document.dispatchEvent(customConfirmEvent);
+};
+
+const acknowledgeModal = (agreement) => {
+  if (agreement) {
+    config.set("enableTTSFilterWarning", true);
+  } else {
+    config.set("enableTTSFilterWarning", false);
+  }
+  config.save();
 };
 
 export const applySettingsToChat = () => {

--- a/src/styles/components/_misc.scss
+++ b/src/styles/components/_misc.scss
@@ -11,6 +11,14 @@
   gap: 2px !important;
 }
 
+.maejok-tts-warning-text {
+  color: red;
+}
+
+.maejok-tts-input-warning-border {
+  border-color: red !important;
+}
+
 .maejok-dim-mode {
   position: fixed;
   top: 0;


### PR DESCRIPTION
### Description
Adds a warning when attempting to send a TTS or SFX that includes a filtered word.

Off by default.  Setting includes agreement popup for user to acknowledge that the backend list can change and is not exposed to this feature could break.

### Screenshots
![Sep-07-2024 13-41-34](https://github.com/user-attachments/assets/6575ea29-f979-449e-8a56-aba52e63ba7d)
